### PR TITLE
Use CFLAGS/LDFLAGS variables.

### DIFF
--- a/monodx/Makefile
+++ b/monodx/Makefile
@@ -9,10 +9,10 @@ all: monodx.dll
 .PHONY: all
 
 %.o: $(SRCDIR)/%.c
-	$(MINGW)-gcc -o $@ -D_WIN32_WINNT=0x0602 --std=c99 -c -Wall -Wno-format -Werror -Wno-pragma-pack -I$(SRCDIR)/.. $<
+	$(MINGW)-gcc -o $@ $(CFLAGS) -D_WIN32_WINNT=0x0602 --std=c99 -c -Wall -Wno-format -Werror -Wno-pragma-pack -I$(SRCDIR)/.. $<
 
 debug.o: $(SRCDIR)/../wine/debug.c
-	$(MINGW)-gcc -o $@ -D_WIN32_WINNT=0x0602 -D__WINESRC__ --std=c99 -c -Wall -Wno-format -Werror -I$(SRCDIR)/.. $<
+	$(MINGW)-gcc -o $@ $(CFLAGS) -D_WIN32_WINNT=0x0602 -D__WINESRC__ --std=c99 -c -Wall -Wno-format -Werror -I$(SRCDIR)/.. $<
 
 monodx.dll: $(C_SRCS:%.c=%.o) debug.o $(H_SRCS:%=$(SRCDIR)/%)
-	$(MINGW)-gcc -o $@ -shared -Wl,--kill-at $(C_SRCS:%.c=%.o) debug.o -luuid -lgdi32
+	$(MINGW)-gcc -o $@ $(LDFLAGS) -shared -Wl,--kill-at $(C_SRCS:%.c=%.o) debug.o -luuid -lgdi32


### PR DESCRIPTION
This makes it possible to generate PDB files for the dll.