### PR TITLE
Improvements needed by Sega Rally launcher

### DIFF
--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/AdapterDetails.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/AdapterDetails.cs
@@ -21,81 +21,103 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 using System;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.DirectX.Direct3D
 {
 	public struct AdapterDetails
 	{
-		private string desc;
+		[StructLayout(LayoutKind.Sequential, CharSet=CharSet.Ansi)]
+		internal struct D3DADAPTER_IDENTIFIER9
+		{
+			[MarshalAs(UnmanagedType.ByValTStr, SizeConst=512)]
+			public string Driver;
+			[MarshalAs(UnmanagedType.ByValTStr, SizeConst=512)]
+			public string Description;
+			[MarshalAs(UnmanagedType.ByValTStr, SizeConst=32)]
+			public string DeviceName;
+			public ulong DriverVersion;
+			public int VendorId;
+			public int DeviceId;
+			public int SubSysId;
+			public int Revision;
+			public Guid DeviceIdentifier;
+			public int WHQLLevel;
+		}
+
+		private D3DADAPTER_IDENTIFIER9 info;
 
 		public Guid DeviceIdentifier {
 			get {
-				throw new NotImplementedException ();
+				return info.DeviceIdentifier;
 			}
 		}
 
 		public int WhqlLevel {
 			get {
-				throw new NotImplementedException ();
+				return info.WHQLLevel;
 			}
 		}
 
 		public int Revision {
 			get {
-				throw new NotImplementedException ();
+				return info.Revision;
 			}
 		}
 
 		public int SubSystemId {
 			get {
-				throw new NotImplementedException ();
+				return info.SubSysId;
 			}
 		}
 
 		public int DeviceId {
 			get {
-				throw new NotImplementedException ();
+				return info.DeviceId;
 			}
 		}
 
 		public int VendorId {
 			get {
-				throw new NotImplementedException ();
+				return info.VendorId;
 			}
 		}
 
 		public Version DriverVersion {
 			get {
-				throw new NotImplementedException ();
+				ulong ver = info.DriverVersion;
+				return new Version((int)(ver >> 48), (int)((ver >> 32)&0xffff), (int)((ver >>16)&0xffff), (int)(ver&0xffff));
 			}
 		}
 
 		public string DeviceName {
 			get {
-				throw new NotImplementedException ();
+				return info.DeviceName;
 			}
 		}
 
 		public string Description {
 			get {
-				return desc;
+				return info.Description;
 			}
 		}
 
 		public string DriverName {
 			get {
-				throw new NotImplementedException ();
+				return info.Driver;
 			}
 		}
 
 		public override string ToString ()
 		{
-			throw new NotImplementedException ();
+			return string.Format(
+				"DeviceIdentifier: {0}\nWhqlLevel: {1}\nRevision: {2}\nSubSystemId: {3}\nDeviceId: {4}\nVendorId: {5}\nDriverVersion: {6}\nDeviceName: {7}\nDescription: {8}\nDriverName: {9}\n",
+				DeviceIdentifier, WhqlLevel, Revision, SubSystemId, DeviceId, VendorId, DriverVersion, DeviceName, Description, DriverName);
 		}
 
-		internal AdapterDetails (string description)
+		internal AdapterDetails (D3DADAPTER_IDENTIFIER9 info)
 		{
-			this.desc = description;
+			this.info = info;
 		}
 	}
 }

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/AdapterInformation.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/AdapterInformation.cs
@@ -38,10 +38,9 @@ namespace Microsoft.DirectX.Direct3D
 			}
 		}
 
-		//TODO: Fill in AdapterDetails structure
 		public AdapterDetails Information {
 			get {
-				return new AdapterDetails ("Default Description");
+				return Manager.GetAdapterIdentifier(_index);
 			}
 		}
 

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/AdapterListCollection.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/AdapterListCollection.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DirectX.Direct3D
 
 		public bool MoveNext ()
 		{
-			if (_index >= _count) return false;
+			if (_index >= (_count - 1)) return false;
 			_index++;
 			return true;
 		}

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Caps.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Caps.cs
@@ -478,7 +478,7 @@ namespace Microsoft.DirectX.Direct3D
 
 		public PresentInterval PresentationIntervals {
 			get {
-				throw new NotImplementedException ();
+				return (PresentInterval)_caps.PresentationIntervals;
 			}
 		}
 

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/DisplayModeCollection.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/DisplayModeCollection.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DirectX.Direct3D
 
 		public bool MoveNext ()
 		{
-			if (_index >= _count) return false;
+			if (_index >= (_count - 1)) return false;
 			_index++;
 			return true;
 		}

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/GraphicsException.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/GraphicsException.cs
@@ -45,10 +45,30 @@ namespace Microsoft.DirectX.Direct3D
 		{
 		}
 
+		internal const int DeviceLost = unchecked((int)0x88760868);
+
 		[EditorBrowsable]
 		public static new Exception GetExceptionFromResultInternal (int resultCode)
 		{
-			throw new NotImplementedException ();
+			switch (resultCode)
+			{
+			case DeviceLost:
+				return new DeviceLostException();
+			default:
+				return new GraphicsException(String.Format("HRESULT {0}", resultCode));
+			}
+		}
+
+		internal static void CheckHR (int hr)
+		{
+			if (hr != 0)
+			{
+				// FIXME: Set DirectXException.LastError?
+				if (!IsExceptionIgnored)
+				{
+					throw GetExceptionFromResultInternal (hr);
+				}
+			}
 		}
 	}
 }

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
@@ -53,6 +53,10 @@ namespace Microsoft.DirectX.Direct3D
 		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
 		internal static extern int d3d9_CheckDeviceType(IntPtr d3d9, int adapter, int devtype, int displayformat, int backbufferformat, bool windowed);
 
+		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
+		internal static extern int d3d9_CheckDeviceFormat(IntPtr d3d9, int adapter, int devtype, int adapterformat, int usage,
+			int restype, int checkformat);
+
 		internal static int GetAdapterDisplayModeCount(int adapter, Format format)
 		{
 			return (int)d3d9_GetAdapterDisplayModeCount(_d3d9, (uint)adapter, (int)format);
@@ -117,24 +121,30 @@ namespace Microsoft.DirectX.Direct3D
 			return (result == 0);
 		}
 
+		private static bool CheckDeviceFormat (int adapter, DeviceType deviceType, Format adapterFormat, Usage usage, ResourceType resourceType, int checkFormat, out int result)
+		{
+			result = d3d9_CheckDeviceFormat(_d3d9, adapter, (int)deviceType, (int)adapterFormat, (int)usage, (int)resourceType, checkFormat);
+			return (result == 0);
+		}
+
 		public static bool CheckDeviceFormat (int adapter, DeviceType deviceType, Format adapterFormat, Usage usage, ResourceType resourceType, DepthFormat checkFormat)
 		{
-			throw new NotImplementedException ();
+			return CheckDeviceFormat(adapter, deviceType, adapterFormat, usage, resourceType, checkFormat, out int dummy);
 		}
 
 		public static bool CheckDeviceFormat (int adapter, DeviceType deviceType, Format adapterFormat, Usage usage, ResourceType resourceType, DepthFormat checkFormat, out int result)
 		{
-			throw new NotImplementedException ();
+			return CheckDeviceFormat(adapter, deviceType, adapterFormat, usage, resourceType, (int)checkFormat, out result);
 		}
 
 		public static bool CheckDeviceFormat (int adapter, DeviceType deviceType, Format adapterFormat, Usage usage, ResourceType resourceType, Format checkFormat)
 		{
-			throw new NotImplementedException ();
+			return CheckDeviceFormat(adapter, deviceType, adapterFormat, usage, resourceType, checkFormat, out int dummy);
 		}
 
 		public static bool CheckDeviceFormat (int adapter, DeviceType deviceType, Format adapterFormat, Usage usage, ResourceType resourceType, Format checkFormat, out int result)
 		{
-			throw new NotImplementedException ();
+			return CheckDeviceFormat(adapter, deviceType, adapterFormat, usage, resourceType, (int)checkFormat, out result);
 		}
 
 		public static bool CheckDeviceMultiSampleType (int adapter, DeviceType deviceType, Format surfaceFormat, bool windowed, MultiSampleType multiSampleType, out int result, out int qualityLevels)

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
@@ -48,6 +48,9 @@ namespace Microsoft.DirectX.Direct3D
 		internal static extern int d3d9_GetAdapterDisplayMode([In] IntPtr d3d9, [In] uint adapter, [In] uint index, [In] int format, [Out] out DisplayMode.D3DDISPLAYMODE mode);
 
 		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
+		internal static extern int d3d9_GetAdapterIdentifier(IntPtr d3d9, uint adapter, int flags, out AdapterDetails.D3DADAPTER_IDENTIFIER9 id);
+
+		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
 		internal static extern int d3d9_GetDeviceCaps([In] IntPtr d3d9, [In] uint adapter, [In] uint type, [Out] out Caps.D3DCAPS9 caps);
 
 		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
@@ -82,6 +85,13 @@ namespace Microsoft.DirectX.Direct3D
 			GraphicsException.CheckHR(
 				d3d9_GetAdapterDisplayMode(_d3d9, (uint)adapter, (uint)index, (int)format, out var mode));
 			return new DisplayMode(mode);
+		}
+
+		internal static AdapterDetails GetAdapterIdentifier(int adapter)
+		{
+			GraphicsException.CheckHR(
+				d3d9_GetAdapterIdentifier(_d3d9, (uint)adapter, 0, out var result));
+			return new AdapterDetails(result);
 		}
 
 		public static AdapterListCollection Adapters {

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
@@ -45,10 +45,10 @@ namespace Microsoft.DirectX.Direct3D
 		internal static extern uint d3d9_GetAdapterDisplayModeCount([In] IntPtr d3d9, [In] uint adapter, [In] int format);
 
 		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
-		internal static extern void d3d9_GetAdapterDisplayMode([In] IntPtr d3d9, [In] uint adapter, [In] uint index, [In] int format, [Out] out DisplayMode.D3DDISPLAYMODE mode);
+		internal static extern int d3d9_GetAdapterDisplayMode([In] IntPtr d3d9, [In] uint adapter, [In] uint index, [In] int format, [Out] out DisplayMode.D3DDISPLAYMODE mode);
 
 		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
-		internal static extern void d3d9_GetDeviceCaps([In] IntPtr d3d9, [In] uint adapter, [In] uint type, [Out] out Caps.D3DCAPS9 caps);
+		internal static extern int d3d9_GetDeviceCaps([In] IntPtr d3d9, [In] uint adapter, [In] uint type, [Out] out Caps.D3DCAPS9 caps);
 
 		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
 		internal static extern int d3d9_CheckDeviceType(IntPtr d3d9, int adapter, int devtype, int displayformat, int backbufferformat, bool windowed);
@@ -79,7 +79,8 @@ namespace Microsoft.DirectX.Direct3D
 
 		internal static DisplayMode GetAdapterDisplayMode(int adapter, int index, Format format)
 		{
-			d3d9_GetAdapterDisplayMode(_d3d9, (uint)adapter, (uint)index, (int)format, out var mode);
+			GraphicsException.CheckHR(
+				d3d9_GetAdapterDisplayMode(_d3d9, (uint)adapter, (uint)index, (int)format, out var mode));
 			return new DisplayMode(mode);
 		}
 
@@ -189,7 +190,8 @@ namespace Microsoft.DirectX.Direct3D
 
 		public static Caps GetDeviceCaps (int adapter, DeviceType deviceType)
 		{
-			d3d9_GetDeviceCaps(_d3d9, (uint)adapter, (uint)deviceType, out var caps);
+			GraphicsException.CheckHR(
+				d3d9_GetDeviceCaps(_d3d9, (uint)adapter, (uint)deviceType, out var caps));
 			return new Caps(caps);
 		}
 

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
@@ -50,6 +50,9 @@ namespace Microsoft.DirectX.Direct3D
 		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
 		internal static extern void d3d9_GetDeviceCaps([In] IntPtr d3d9, [In] uint adapter, [In] uint type, [Out] out Caps.D3DCAPS9 caps);
 
+		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
+		internal static extern int d3d9_CheckDeviceType(IntPtr d3d9, int adapter, int devtype, int displayformat, int backbufferformat, bool windowed);
+
 		internal static int GetAdapterDisplayModeCount(int adapter, Format format)
 		{
 			return (int)d3d9_GetAdapterDisplayModeCount(_d3d9, (uint)adapter, (int)format);
@@ -105,12 +108,13 @@ namespace Microsoft.DirectX.Direct3D
 
 		public static bool CheckDeviceType (int adapter, DeviceType checkType, Format displayFormat, Format backBufferFormat, bool windowed)
 		{
-			throw new NotImplementedException ();
+			return CheckDeviceType(adapter, checkType, displayFormat, backBufferFormat, windowed, out int dummy);
 		}
 
 		public static bool CheckDeviceType (int adapter, DeviceType checkType, Format displayFormat, Format backBufferFormat, bool windowed, out int result)
 		{
-			throw new NotImplementedException ();
+			result = d3d9_CheckDeviceType(_d3d9, adapter, (int)checkType, (int)displayFormat, (int)backBufferFormat, windowed);
+			return (result == 0);
 		}
 
 		public static bool CheckDeviceFormat (int adapter, DeviceType deviceType, Format adapterFormat, Usage usage, ResourceType resourceType, DepthFormat checkFormat)

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DirectX.Direct3D
 
 		internal static DisplayMode GetAdapterCurrentDisplayMode(int adapter)
 		{
-			Marshal.ThrowExceptionForHR(
+			GraphicsException.CheckHR(
 				d3d9_GetAdapterCurrentDisplayMode(_d3d9, (uint)adapter, out var mode));
 			return new DisplayMode(mode);
 		}

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
@@ -61,6 +61,10 @@ namespace Microsoft.DirectX.Direct3D
 		internal static extern int d3d9_CheckDepthStencilMatch(IntPtr d3d9, int adapter, int devtype, int adapterformat,
 			int rendertargetformat, int depthstencilformat);
 
+		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
+		internal static extern int d3d9_CheckDeviceMultiSampleType(IntPtr d3d9, int adapter, int devtype, int format,
+			bool windowed, int mstype, out int qualitylevels);
+
 		internal static int GetAdapterDisplayModeCount(int adapter, Format format)
 		{
 			return (int)d3d9_GetAdapterDisplayModeCount(_d3d9, (uint)adapter, (int)format);
@@ -153,12 +157,13 @@ namespace Microsoft.DirectX.Direct3D
 
 		public static bool CheckDeviceMultiSampleType (int adapter, DeviceType deviceType, Format surfaceFormat, bool windowed, MultiSampleType multiSampleType, out int result, out int qualityLevels)
 		{
-			throw new NotImplementedException ();
+			result = d3d9_CheckDeviceMultiSampleType(_d3d9, adapter, (int)deviceType, (int)surfaceFormat, windowed, (int)multiSampleType, out qualityLevels);
+			return (result == 0);
 		}
 
 		public static bool CheckDeviceMultiSampleType (int adapter, DeviceType deviceType, Format surfaceFormat, bool windowed, MultiSampleType multiSampleType)
 		{
-			throw new NotImplementedException ();
+			return CheckDeviceMultiSampleType(adapter, deviceType, surfaceFormat, windowed, multiSampleType, out int dummy, out int dummy2);
 		}
 
 		public static bool CheckDepthStencilMatch (int adapter, DeviceType deviceType, Format adapterFormat, Format renderTargetFormat, DepthFormat depthStencilFormat, out int result)

--- a/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
+++ b/Microsoft.DirectX.Direct3D/Microsoft.DirectX.Direct3D/Manager.cs
@@ -57,6 +57,10 @@ namespace Microsoft.DirectX.Direct3D
 		internal static extern int d3d9_CheckDeviceFormat(IntPtr d3d9, int adapter, int devtype, int adapterformat, int usage,
 			int restype, int checkformat);
 
+		[DllImport("monodx.dll", CallingConvention=CallingConvention.Cdecl)]
+		internal static extern int d3d9_CheckDepthStencilMatch(IntPtr d3d9, int adapter, int devtype, int adapterformat,
+			int rendertargetformat, int depthstencilformat);
+
 		internal static int GetAdapterDisplayModeCount(int adapter, Format format)
 		{
 			return (int)d3d9_GetAdapterDisplayModeCount(_d3d9, (uint)adapter, (int)format);
@@ -159,12 +163,13 @@ namespace Microsoft.DirectX.Direct3D
 
 		public static bool CheckDepthStencilMatch (int adapter, DeviceType deviceType, Format adapterFormat, Format renderTargetFormat, DepthFormat depthStencilFormat, out int result)
 		{
-			throw new NotImplementedException ();
+			result = d3d9_CheckDepthStencilMatch(_d3d9, adapter, (int)deviceType, (int)adapterFormat, (int)renderTargetFormat, (int)depthStencilFormat);
+			return (result == 0);
 		}
 
 		public static bool CheckDepthStencilMatch (int adapter, DeviceType deviceType, Format adapterFormat, Format renderTargetFormat, DepthFormat depthStencilFormat)
 		{
-			throw new NotImplementedException ();
+			return CheckDepthStencilMatch(adapter, deviceType, adapterFormat, renderTargetFormat, depthStencilFormat, out int dummy);
 		}
 
 		public static bool CheckDeviceFormatConversion (int adapter, DeviceType deviceType, Format sourceFormat, Format targetFormat, out int result)

--- a/Microsoft.DirectX/AssemblyInfo.cs
+++ b/Microsoft.DirectX/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Runtime.InteropServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.2902.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Microsoft.DirectX/Microsoft.DirectX/DirectXException.cs
+++ b/Microsoft.DirectX/Microsoft.DirectX/DirectXException.cs
@@ -85,12 +85,12 @@ namespace Microsoft.DirectX
 
 		public static void IgnoreExceptions ()
 		{
-			throw new NotImplementedException ();
+			IsExceptionIgnored = true;
 		}
 
 		public static void EnableExceptions ()
 		{
-			throw new NotImplementedException ();
+			IsExceptionIgnored = false;
 		}
 
 		public static string GetDirectXErrorString (int errorCode)

--- a/monodx/main.c
+++ b/monodx/main.c
@@ -104,6 +104,12 @@ HRESULT CDECL d3d9_GetAdapterDisplayMode(IDirect3D9 *iface, UINT adapter, UINT i
     return IDirect3D9_EnumAdapterModes(iface, adapter, format, index, mode);
 }
 
+HRESULT CDECL d3d9_GetAdapterIdentifier(IDirect3D9 *iface, UINT adapter, UINT flags, D3DADAPTER_IDENTIFIER9 *id)
+{
+    WINE_TRACE("iface %p, adapter %u, flags 0x%x\n", iface, adapter, flags);
+    return IDirect3D9_GetAdapterIdentifier(iface, adapter, flags, id);
+}
+
 HRESULT CDECL d3d9_GetDeviceCaps(IDirect3D9 *iface, UINT adapter, UINT type, D3DCAPS9 *caps)
 {
     WINE_TRACE("iface %p, adapter %u, type %u, caps %p\n", iface, adapter, type, caps);

--- a/monodx/main.c
+++ b/monodx/main.c
@@ -110,6 +110,13 @@ void CDECL d3d9_GetDeviceCaps(IDirect3D9 *iface, UINT adapter, UINT type, D3DCAP
     IDirect3D9_GetDeviceCaps(iface, adapter, type, caps);
 }
 
+HRESULT CDECL d3d9_CheckDeviceType(IDirect3D9 *iface, UINT adapter, D3DDEVTYPE devtype, D3DFORMAT displayformat,
+	D3DFORMAT backbufferformat, BOOL windowed)
+{
+    WINE_TRACE("iface %p, adapter %u, devtype %u, format %u/%u, windowed\n", iface, adapter, devtype, displayformat, backbufferformat, windowed);
+    return IDirect3D9_CheckDeviceType(iface, adapter, devtype, displayformat, backbufferformat, windowed);
+}
+
 HRESULT CDECL dinput_Create(IDirectInput8 **iface)
 {
     HRESULT hr;

--- a/monodx/main.c
+++ b/monodx/main.c
@@ -98,16 +98,16 @@ HRESULT CDECL d3d9_GetAdapterCurrentDisplayMode(IDirect3D9 *iface, UINT adapter,
     return IDirect3D9_GetAdapterDisplayMode(iface, adapter, mode);
 }
 
-void CDECL d3d9_GetAdapterDisplayMode(IDirect3D9 *iface, UINT adapter, UINT index, UINT format, D3DDISPLAYMODE *mode)
+HRESULT CDECL d3d9_GetAdapterDisplayMode(IDirect3D9 *iface, UINT adapter, UINT index, UINT format, D3DDISPLAYMODE *mode)
 {
     WINE_TRACE("iface %p, adapter %u, index %u, mode %p\n", iface, adapter, index, mode);
-    IDirect3D9_EnumAdapterModes(iface, adapter, format, index, mode);
+    return IDirect3D9_EnumAdapterModes(iface, adapter, format, index, mode);
 }
 
-void CDECL d3d9_GetDeviceCaps(IDirect3D9 *iface, UINT adapter, UINT type, D3DCAPS9 *caps)
+HRESULT CDECL d3d9_GetDeviceCaps(IDirect3D9 *iface, UINT adapter, UINT type, D3DCAPS9 *caps)
 {
     WINE_TRACE("iface %p, adapter %u, type %u, caps %p\n", iface, adapter, type, caps);
-    IDirect3D9_GetDeviceCaps(iface, adapter, type, caps);
+    return IDirect3D9_GetDeviceCaps(iface, adapter, type, caps);
 }
 
 HRESULT CDECL d3d9_CheckDeviceType(IDirect3D9 *iface, UINT adapter, D3DDEVTYPE devtype, D3DFORMAT displayformat,

--- a/monodx/main.c
+++ b/monodx/main.c
@@ -125,6 +125,14 @@ HRESULT CDECL d3d9_CheckDeviceFormat(IDirect3D9 *iface, UINT adapter, D3DDEVTYPE
     return IDirect3D9_CheckDeviceFormat(iface, adapter, devtype, adapterformat, usage, restype, checkformat);
 }
 
+HRESULT CDECL d3d9_CheckDepthStencilMatch(IDirect3D9 *iface, UINT adapter, D3DDEVTYPE devtype, D3DFORMAT adapterformat,
+	D3DFORMAT rendertargetformat, D3DFORMAT depthstencilformat)
+{
+    WINE_TRACE("iface %p, adapter %u, devtype %u, adapterformat %u, rendertargetformat %u, depthsencilformat %u\n",
+		iface, adapter, devtype, adapterformat, rendertargetformat, depthstencilformat);
+	return IDirect3D9_CheckDepthStencilMatch(iface, adapter, devtype, adapterformat, rendertargetformat, depthstencilformat);
+}
+
 HRESULT CDECL dinput_Create(IDirectInput8 **iface)
 {
     HRESULT hr;

--- a/monodx/main.c
+++ b/monodx/main.c
@@ -117,6 +117,14 @@ HRESULT CDECL d3d9_CheckDeviceType(IDirect3D9 *iface, UINT adapter, D3DDEVTYPE d
     return IDirect3D9_CheckDeviceType(iface, adapter, devtype, displayformat, backbufferformat, windowed);
 }
 
+HRESULT CDECL d3d9_CheckDeviceFormat(IDirect3D9 *iface, UINT adapter, D3DDEVTYPE devtype, D3DFORMAT adapterformat,
+	DWORD usage, D3DRESOURCETYPE restype, D3DFORMAT checkformat)
+{
+    WINE_TRACE("iface %p, adapter %u, devtype %u, adapterformat %u, usage 0x%x, restype %u checkformat %u\n",
+		iface, adapter, devtype, adapterformat, usage, restype, checkformat);
+    return IDirect3D9_CheckDeviceFormat(iface, adapter, devtype, adapterformat, usage, restype, checkformat);
+}
+
 HRESULT CDECL dinput_Create(IDirectInput8 **iface)
 {
     HRESULT hr;

--- a/monodx/main.c
+++ b/monodx/main.c
@@ -125,6 +125,14 @@ HRESULT CDECL d3d9_CheckDeviceFormat(IDirect3D9 *iface, UINT adapter, D3DDEVTYPE
     return IDirect3D9_CheckDeviceFormat(iface, adapter, devtype, adapterformat, usage, restype, checkformat);
 }
 
+HRESULT CDECL d3d9_CheckDeviceMultiSampleType(IDirect3D9 *iface, UINT adapter, D3DDEVTYPE devtype, D3DFORMAT format,
+	BOOL windowed, D3DMULTISAMPLE_TYPE mstype, DWORD *qualitylevels)
+{
+    WINE_TRACE("iface %p, adapter %u, devtype %u, format %u, windowed %u, mstype %u\n",
+		iface, adapter, devtype, format, windowed, mstype);
+    return IDirect3D9_CheckDeviceMultiSampleType(iface, adapter, devtype, format, windowed, mstype, qualitylevels);
+}
+
 HRESULT CDECL d3d9_CheckDepthStencilMatch(IDirect3D9 *iface, UINT adapter, D3DDEVTYPE devtype, D3DFORMAT adapterformat,
 	D3DFORMAT rendertargetformat, D3DFORMAT depthstencilformat)
 {


### PR DESCRIPTION
Most of this is about querying display adapter information, but there's also some work on exceptions and a specific version for Microsoft.DirectX.dll so applications linked to native can work.